### PR TITLE
Blossom network upgrade

### DIFF
--- a/src/Lykke.Service.Zcash.Api.Services/BlockchainReader.cs
+++ b/src/Lykke.Service.Zcash.Api.Services/BlockchainReader.cs
@@ -77,6 +77,11 @@ namespace Lykke.Service.Zcash.Api.Services
             return await SendRpcAsync<Block>(RPCOperations.getblock, blockHash);
         }
 
+        public async Task<Models.BlockchainInfo> GetBlockchainInfo()
+        {
+            return await SendRpcAsync<Models.BlockchainInfo>(RPCOperations.getblockchaininfo);
+        }
+
         public async Task<T> SendRpcAsync<T>(RPCOperations command, params object[] parameters)
         {
             var result = await SendRpcAsync(command, parameters);

--- a/src/Lykke.Service.Zcash.Api.Services/BlockchainService.cs
+++ b/src/Lykke.Service.Zcash.Api.Services/BlockchainService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Globalization;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -158,7 +159,11 @@ namespace Lykke.Service.Zcash.Api.Services
 
             var raw = await _blockchainReader.DecodeRawTransaction(hex);
 
-            var ctx = JsonConvert.SerializeObject((hex, inputs));
+            var blockchainInfo = await _blockchainReader.GetBlockchainInfo();
+
+            var branchId = uint.Parse(blockchainInfo.Consensus.NextBlock, NumberStyles.HexNumber);
+
+            var ctx = JsonConvert.SerializeObject((hex, inputs, branchId));
 
             await _operationRepository.UpsertAsync(operationId, type, items, fee, subtractFees, asset.Id, raw.ExpiryHeight);
 

--- a/src/Lykke.Service.Zcash.Api.Services/BlockchainService.cs
+++ b/src/Lykke.Service.Zcash.Api.Services/BlockchainService.cs
@@ -176,6 +176,10 @@ namespace Lykke.Service.Zcash.Api.Services
             }
             catch (NBitcoin.RPC.RPCException ex) when (ex.RPCCode == NBitcoin.RPC.RPCErrorCode.RPC_VERIFY_REJECTED)
             {
+                await _log.WriteWarningAsync(nameof(BroadcastAsync),
+                    $"Transaction: {transaction}, Error: {ex.ToString()}",
+                    $"Transaction rejected");
+
                 throw new BlockchainException(BlockchainException.ErrorCode.Rejected, "Transaction rejected");
             }
         }

--- a/src/Lykke.Service.Zcash.Api.Services/IBlockchainReader.cs
+++ b/src/Lykke.Service.Zcash.Api.Services/IBlockchainReader.cs
@@ -17,5 +17,6 @@ namespace Lykke.Service.Zcash.Api.Services
         Task<string> CreateRawTransaction(Utxo[] inputs, Dictionary<string, decimal> outputs);
         Task<RawTransaction> DecodeRawTransaction(string transaction);
         Task<Block> GetBlockAsync(string blockHash);
+        Task<BlockchainInfo> GetBlockchainInfo();
     }
 }

--- a/src/Lykke.Service.Zcash.Api.Services/Models/BlockchainInfo.cs
+++ b/src/Lykke.Service.Zcash.Api.Services/Models/BlockchainInfo.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Lykke.Service.Zcash.Api.Services.Models
+{
+    public class BlockchainInfo
+    {
+        public ConsensusInfo Consensus { get; set; }
+
+        public class ConsensusInfo
+        {
+            public string NextBlock { get; set; }
+        }
+    }
+}

--- a/tests/Lykke.Service.Zcash.Api.Tests/BlockchainServiceTests.cs
+++ b/tests/Lykke.Service.Zcash.Api.Tests/BlockchainServiceTests.cs
@@ -109,6 +109,10 @@ namespace Lykke.Service.Zcash.Api.Tests
                 .Setup(x => x.DecodeRawTransaction(It.IsAny<string>()))
                 .Returns((string hex) => Task.FromResult(new RawTransaction()));
 
+            blockchainReader
+                .Setup(x => x.GetBlockchainInfo())
+                .Returns(() => Task.FromResult(new BlockchainInfo { Consensus = new BlockchainInfo.ConsensusInfo { NextBlock = "76b809bb" } }));
+
             blockhainService = new BlockchainService(log,
                 blockchainReader.Object,
                 addressRepository.Object,


### PR DESCRIPTION
Branch ID has been changed for Blossom, see https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html#blossom. Branch ID is used in signature algorithm, but transaction format or version have not been changed so we have to route it to the sign service from API.